### PR TITLE
feat: add Claude Agent SDK chat example

### DIFF
--- a/examples/claude_agent_sdk_chat/README.md
+++ b/examples/claude_agent_sdk_chat/README.md
@@ -1,0 +1,74 @@
+# Claude Agent SDK Chat with Agentic Learning
+
+A simple REPL-style chat demonstrating how to use the Claude Agent SDK with the **Agentic Learning SDK** for persistent memory.
+
+## Overview
+
+This example shows how to add persistent memory to Claude Agent SDK applications. The agent remembers past conversations across sessions with zero architectural changes - just wrap your `query()` call with `learning()`.
+
+## Installation
+
+```bash
+npm install @anthropic-ai/claude-agent-sdk @letta-ai/agentic-learning typescript @types/node tsx
+```
+
+## Setup
+
+Set your API keys:
+```bash
+export ANTHROPIC_API_KEY="your-anthropic-key"
+export LETTA_API_KEY="your-letta-key"  # Get one at letta.com
+```
+
+## Running
+
+```bash
+npx tsx chat.ts
+```
+
+Type messages to chat with Claude. Type "exit" to quit.
+
+## How It Works
+
+The key is wrapping each query in the `learning()` context:
+
+```typescript
+import * as readline from "readline";
+import { learning } from '@letta-ai/agentic-learning';
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+console.log('Chat with Claude (type "exit" to quit)\n');
+
+(function ask() {
+  rl.question('You: ', async (input) => {
+    if (input.trim().toLowerCase() === 'exit') return rl.close();
+    if (!input.trim()) return ask();
+
+    // Wrap each query in learning() to enable persistent memory across messages.
+    // The SDK automatically injects relevant context from previous conversations.
+    await learning({ agent: 'claude-chat-demo' }, async () => {
+      // Use require() inside learning() so the SDK can intercept and inject memory
+      const { query } = require("@anthropic-ai/claude-agent-sdk");
+      for await (const msg of query({ prompt: input, options: { model: "haiku" } })) {
+        if (msg.type === 'assistant') {
+          const text = msg.message?.content.find((c: any) => c.type === 'text');
+          if (text?.text) console.log(`\nClaude: ${text.text}\n`);
+        }
+      }
+    });
+    ask();
+  });
+})();
+```
+
+**Key points:**
+- `learning()` wraps each query to enable persistent memory
+- Use `require()` inside the callback so the SDK can intercept and inject memory
+- The agent identifier (`'claude-chat-demo'`) groups memories together
+
+## Resources
+
+- [Claude Agent SDK Documentation](https://docs.anthropic.com)
+- [Agentic Learning SDK](https://github.com/letta-ai/agentic-learning-sdk)
+- [Get Letta API Key](https://www.letta.com/)

--- a/examples/claude_agent_sdk_chat/chat.ts
+++ b/examples/claude_agent_sdk_chat/chat.ts
@@ -1,0 +1,27 @@
+import * as readline from "readline";
+import { learning } from '@letta-ai/agentic-learning';
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+console.log('Chat with Claude (type "exit" to quit)\n');
+
+(function ask() {
+  rl.question('You: ', async (input) => {
+    if (input.trim().toLowerCase() === 'exit') return rl.close();
+    if (!input.trim()) return ask();
+
+    // Wrap each query in learning() to enable persistent memory across messages.
+    // The SDK automatically injects relevant context from previous conversations.
+    await learning({ agent: 'claude-chat-demo' }, async () => {
+      // Use require() inside learning() so the SDK can intercept and inject memory
+      const { query } = require("@anthropic-ai/claude-agent-sdk");
+      for await (const msg of query({ prompt: input, options: { model: "haiku" } })) {
+        if (msg.type === 'assistant') {
+          const text = msg.message?.content.find((c: any) => c.type === 'text');
+          if (text?.text) console.log(`\nClaude: ${text.text}\n`);
+        }
+      }
+    });
+    ask();
+  });
+})();

--- a/examples/claude_agent_sdk_chat/package.json
+++ b/examples/claude_agent_sdk_chat/package.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.37",
+    "@letta-ai/agentic-learning": "^0.4.1",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@types/node": "^24.7.2",
+    "tsx": "^4.20.6",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/claude_agent_sdk_chat/tsconfig.json
+++ b/examples/claude_agent_sdk_chat/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary
- Adds a simple REPL-style chat example using the Claude Agent SDK
- Demonstrates persistent memory with the `learning()` wrapper
- Minimal code (~27 lines) to show the core integration pattern

## Test plan
- [ ] Run `npx tsx chat.ts` and verify chat works
- [ ] Verify memory persists across restarts