### PR TITLE
chore: upgrade letta-client from alpha to stable (>=1.7.1)

### DIFF
--- a/examples/pydantic_ai_demo/anthropic_example.py
+++ b/examples/pydantic_ai_demo/anthropic_example.py
@@ -32,7 +32,5 @@ def ask_agent(message: str):
 
 # Memory automatically persists across LLM API calls
 ask_agent("My name is Alice.")
-ask_agent("What's my name?")
-sleep-time
-
+time.sleep(8)  # Wait for sleeptime to process
 ask_agent("What's my name?")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "pydantic>=1.9.2",
     "pydantic-core>=2.18.2",
     "typing_extensions>=4.0.0",
-    "letta_client==1.0.0a20",
+    "letta_client>=1.7.1",
 ]
 
 # Optional dependencies for different providers

--- a/python/src/agentic_learning/client/agents/client.py
+++ b/python/src/agentic_learning/client/agents/client.py
@@ -6,7 +6,7 @@ Provides agent management operations with name-based APIs.
 
 from typing import Any, List, Optional
 
-from letta_client.types import AgentState, SleeptimeManagerParam
+from letta_client.types import AgentState
 from .sleeptime import SleeptimeClient, AsyncSleeptimeClient
 from ..utils import memory_placeholder
 
@@ -60,13 +60,6 @@ class AgentsClient:
             embedding="openai/text-embedding-3-small",
             tags=["agentic-learning-sdk"],
             enable_sleeptime=True,
-        )
-        self._letta.groups.update(
-            group_id=agent.multi_agent_group.id,
-            manager_config=SleeptimeManagerParam(
-                manager_type="sleeptime",
-                sleeptime_agent_frequency=2,
-            ),
         )
         return agent
     
@@ -203,13 +196,6 @@ class AsyncAgentsClient:
             embedding="openai/text-embedding-3-small",
             tags=["agentic-learning-sdk"],
             enable_sleeptime=True,
-        )
-        await self._letta.groups.update(
-            group_id=agent.multi_agent_group.id,
-            manager_config=SleeptimeManagerParam(
-                manager_type="sleeptime",
-                sleeptime_agent_frequency=2,
-            ),
         )
         return agent
     

--- a/python/src/agentic_learning/client/agents/sleeptime.py
+++ b/python/src/agentic_learning/client/agents/sleeptime.py
@@ -5,7 +5,7 @@ Provides sleeptime management operations for agents.
 """
 
 from typing import Any, Optional
-from letta_client.types import AgentState, SleeptimeManagerParam
+from letta_client.types import AgentState
 
 
 # =============================================================================
@@ -50,18 +50,21 @@ class SleeptimeClient:
             include=["agent.blocks", "agent.managed_group", "agent.tags"],
         )
     
-    def update(self, agent: str, model: Optional[str], frequency: Optional[int]) -> Optional[AgentState]:
+    def update(self, agent: str, model: Optional[str], frequency: Optional[int] = None) -> Optional[AgentState]:
         """
         Update the sleeptime configuration for the agent.
 
         Args:
             agent (str): Name of the primary agent to update corresponding sleeptime agent for
             model (str | None): Model to use for the sleeptime agent
-            frequency (int | None): Frequency at which to invoke the sleeptime memory agent (num turns)
+            frequency (int | None): Frequency parameter (currently not supported)
 
         Returns:
             (AgentState | None): Updated sleeptime agent if found, None otherwise
         """
+        if frequency is not None:
+            raise NotImplementedError("Sleeptime frequency updates are not currently supported")
+        
         primary_agent = self._parent.agents.retrieve(agent=agent)
         if not primary_agent or not primary_agent.multi_agent_group:
             return None
@@ -69,14 +72,12 @@ class SleeptimeClient:
 
         if model:
             sleeptime_agent = self._letta.agents.update(agent_id=sleeptime_agent_id, model=model)
-        if frequency:
-            self._letta.groups.update(group_id=primary_agent.multi_agent_group.id, manager_config=SleeptimeManagerParam(sleeptime_agent_frequency=frequency))
-            sleeptime_agent = self._letta.agents.retrieve(
-                agent_id=sleeptime_agent_id,
-                include=["agent.blocks", "agent.managed_group", "agent.tags"],
-            )
+            return sleeptime_agent
         
-        return sleeptime_agent
+        return self._letta.agents.retrieve(
+            agent_id=sleeptime_agent_id,
+            include=["agent.blocks", "agent.managed_group", "agent.tags"],
+        )
 
 
 # =============================================================================
@@ -121,18 +122,21 @@ class AsyncSleeptimeClient:
             include=["agent.blocks", "agent.managed_group", "agent.tags"],
         )
     
-    async def update(self, agent: str, model: Optional[str], frequency: Optional[int]) -> Optional[AgentState]:
+    async def update(self, agent: str, model: Optional[str], frequency: Optional[int] = None) -> Optional[AgentState]:
         """
         Update the sleeptime configuration for the agent.
 
         Args:
             agent (str): Name of the primary agent to update corresponding sleeptime agent for
             model (str | None): Model to use for the sleeptime agent
-            frequency (int | None): Frequency at which to invoke the sleeptime memory agent (num turns)
+            frequency (int | None): Frequency parameter (currently not supported)
 
         Returns:
             (AgentState | None): Updated sleeptime agent if found, None otherwise
         """
+        if frequency is not None:
+            raise NotImplementedError("Sleeptime frequency updates are not currently supported")
+        
         primary_agent = await self._parent.agents.retrieve(agent=agent)
         if not primary_agent or not primary_agent.multi_agent_group:
             return None
@@ -140,12 +144,10 @@ class AsyncSleeptimeClient:
 
         if model:
             sleeptime_agent = await self._letta.agents.update(agent_id=sleeptime_agent_id, model=model)
-        if frequency:
-            await self._letta.groups.update(group_id=primary_agent.multi_agent_group.id, manager_config=SleeptimeManagerParam(sleeptime_agent_frequency=frequency))
-            sleeptime_agent = await self._letta.agents.retrieve(
-                agent_id=sleeptime_agent_id,
-                include=["agent.blocks", "agent.managed_group", "agent.tags"],
-            )
+            return sleeptime_agent
         
-        return sleeptime_agent
+        return await self._letta.agents.retrieve(
+            agent_id=sleeptime_agent_id,
+            include=["agent.blocks", "agent.managed_group", "agent.tags"],
+        )
 


### PR DESCRIPTION
## Summary

Upgrades letta-client from `1.0.0a20` (alpha) to `>=1.7.1` (stable).

## Breaking Changes Addressed

- **`SleeptimeManagerParam`** - Removed (no longer exists in new SDK)
- **`groups.update()`** - Removed (API no longer available)
- **Sleeptime frequency updates** - Now raises `NotImplementedError` since the underlying API is gone

## Changes

- `pyproject.toml`: `letta_client==1.0.0a20` → `letta_client>=1.7.1`
- `client/agents/client.py`: Remove `SleeptimeManagerParam` import and `groups.update()` calls
- `client/agents/sleeptime.py`: Remove `SleeptimeManagerParam`, stub frequency updates

## Testing

Tested with $LETTA_API_KEY:
- ✅ All imports work
- ✅ Client creation
- ✅ List agents (found 50)
- ✅ Create agent with `enable_sleeptime=True`
- ✅ Delete agent

Written by Cameron ◯ Letta Code